### PR TITLE
chore: upgrade to latest pkg while releasing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update --fix-missing
+        sudo apt full-upgrade -y
         sudo apt install -y \
           mosquitto-dev \
           libboost-program-options-dev \

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           docker run --name rpi-container -v ${{ github.workspace }}:/app rpi-docker-image /usr/bin/bash -c "
             apt update --fix-missing &&
+            apt full-upgrade -y &&
             apt install -y \
               wget \
               curl \

--- a/.github/workflows/qemu_build.yml
+++ b/.github/workflows/qemu_build.yml
@@ -74,6 +74,7 @@ jobs:
       run: |
         sshpass -p "raspberry" ssh -o StrictHostKeyChecking=no -p 5555 pi@localhost "\
           sudo apt update && \
+          sudo apt full-upgrade -y && \
           sudo apt install -y \
           wget \
           curl \


### PR DESCRIPTION
#236
No idea when the next stable Pi OS will be released.
Always upgrade to latest packages while releasing.