### PR TITLE
feat: enable libcamera selection in addition to v4l2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,31 +16,28 @@
 
 Turn your Raspberry Pi into a low-latency home security camera using the V4L2 DMA hardware encoder and WebRTC. [[demo video](https://www.youtube.com/watch?v=JZ5bcSAsXog)]
 
-- Pure P2P-based camera allows video playback and download without a media server.
+- Supports real-time adjustment of camera parameters and video recording download.
 - Support [multiple users](doc/pi_4b_users_demo.gif) for simultaneous live streaming.
-- Support signaling via [WHEP](https://www.ietf.org/archive/id/draft-ietf-wish-whep-02.html) or MQTT.
-
-# How to use
-
-To set up the environment, please check out the [tutorial video](https://youtu.be/g5Npb6DsO-0) or the steps below.
-
-* Download and run the binary file from [Releases](https://github.com/TzuHuanTai/RaspberryPi_WebRTC/releases).
-* Set up the network configuration and create a new client using one of the following options:
+- Support signaling 
 
   **MQTT**
     * [PiCamera.js](https://www.npmjs.com/package/picamera.js)
-    * [Pi Camera App](https://github.com/TzuHuanTai/Pi-Camera) (Android)
-    * [Pi Camera Web](https://picamera.live)
+    * [Pi Camera App](https://github.com/TzuHuanTai/Pi-Camera) *(for development and testing)*
+    * [Pi Camera Web](https://picamera.live) *(for development and testing)*
 
-  **WHEP**
+  **[WHEP](https://www.ietf.org/archive/id/draft-ietf-wish-whep-02.html)**
     * [Home Assistant](https://www.home-assistant.io)
     * [eyevinn/webrtc-player](https://www.npmjs.com/package/@eyevinn/webrtc-player)
+
+# Quick Start
+
+To set up the environment, please check out the [tutorial video](https://youtu.be/g5Npb6DsO-0) or the steps below.
 
 ## Hardware Requirements
 
 <img src="https://assets.raspberrypi.com/static/51035ec4c2f8f630b3d26c32e90c93f1/2b8d7/zero2-hero.webp" height="96">
 
-* Raspberry Pi (Zero 2W/3/3B+/4B/5).
+* Raspberry Pi (Zero 2W/3B/3B+/4B/5).
 * CSI or USB Camera Module.
 
 ## Environment Setup
@@ -58,22 +55,23 @@ Use the [Raspberry Pi Imager](https://www.raspberrypi.com/software/) to install 
 
 </details>
 
-### 2. Install essential libraries
+### 2. Install Dependencies
 
 ```bash
 sudo apt install libmosquitto1 pulseaudio libavformat59 libswscale6
 ```
 
-### 3. Download and unzip the binary file
+### 3. Download & Unpack
 
+Prepare the binary file from [Releases](https://github.com/TzuHuanTai/RaspberryPi_WebRTC/releases).
 ```bash
 wget https://github.com/TzuHuanTai/RaspberryPi_WebRTC/releases/latest/download/pi_webrtc-v1.0.5_MQTT_raspios-bookworm-arm64.tar.gz
 tar -xzf pi_webrtc-v1.0.5_MQTT_raspios-bookworm-arm64.tar.gz
 ```
 
-### 4. Setup MQTT
+### 4. Set Up MQTT
 
-An MQTT server is required for communication between devices. For remote access, free cloud options include [HiveMQ](https://www.hivemq.com) and [EMQX](https://www.emqx.com/en).
+You can use a free cloud MQTT service like  [HiveMQ](https://www.hivemq.com) or [EMQX](https://www.emqx.com/en), or set up your own self-hosted broker.
 
 <details>
   <summary>
@@ -90,21 +88,22 @@ An MQTT server is required for communication between devices. For remote access,
 * Run the command based on your network settings and `UID` on the Raspberry Pi:
     ```bash
     ./pi_webrtc \
-        --use_libcamera \
+        --camera=libcamera:0 \
         --fps=30 \
         --width=1280 \
         --height=960 \
-        --hw_accel \
-        --no_audio \
         --mqtt_host=your.mqtt.cloud \
         --mqtt_port=8883 \
         --mqtt_username=hakunamatata \
         --mqtt_password=Wonderful \
-        --uid=your-custom-uid
+        --uid=your-custom-uid \
+        --no_audio \
+        --hw_accel # Only Pi Zero 2W, 3B, 4B support hw encoding
     ```
 
 > [!IMPORTANT]
-> The `--hw_accel` flag is used for Pi Zero 2W, 3, 3B+, and 4B. For Pi 5 or other SBCs without a hardware encoder, run this command in software encoding mode by removing the `--hw_accel` flag.
+> Use `--hw_accel` for Pi Zero 2W, 3B, 3B+, and 4B. Remove for Pi 5 or devices without hardware encoding.
+
 * Go to the Live page to enjoy real-time streaming!
 
 <p align=center>
@@ -113,7 +112,7 @@ An MQTT server is required for communication between devices. For remote access,
 
 # [Advance](https://github.com/TzuHuanTai/RaspberryPi_WebRTC/wiki/Advanced-Settings)
 
-- [Using the Legacy V4L2 Driver](https://github.com/TzuHuanTai/RaspberryPi-WebRTC/wiki/Advanced-Settings#using-the-legacy-v4l2-driver) for usb camera
+- [Using the V4L2 Driver](https://github.com/TzuHuanTai/RaspberryPi-WebRTC/wiki/Advanced-Settings#using-the-legacy-v4l2-driver) for usb camera
 - [Run as Linux Service](https://github.com/TzuHuanTai/RaspberryPi-WebRTC/wiki/Advanced-Settings#run-as-linux-service)
 - [Recording](https://github.com/TzuHuanTai/RaspberryPi-WebRTC/wiki/Advanced-Settings#recording)
 - [Two-way communication](https://github.com/TzuHuanTai/RaspberryPi-WebRTC/wiki/Advanced-Settings#two-way-communication)

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ sudo apt install libmosquitto1 pulseaudio libavformat59 libswscale6
 
 Prepare the binary file from [Releases](https://github.com/TzuHuanTai/RaspberryPi_WebRTC/releases).
 ```bash
-wget https://github.com/TzuHuanTai/RaspberryPi_WebRTC/releases/latest/download/pi_webrtc-v1.0.5_MQTT_raspios-bookworm-arm64.tar.gz
-tar -xzf pi_webrtc-v1.0.5_MQTT_raspios-bookworm-arm64.tar.gz
+wget https://github.com/TzuHuanTai/RaspberryPi_WebRTC/releases/latest/download/pi_webrtc-v1.0.6-rc.1_MQTT_raspios-bookworm-arm64.tar.gz
+tar -xzf pi_webrtc-v1.0.6-rc.1_MQTT_raspios-bookworm-arm64.tar.gz
 ```
 
 ### 4. Set Up MQTT

--- a/src/args.h
+++ b/src/args.h
@@ -10,6 +10,7 @@ struct Args {
     int fps = 30;
     int width = 640;
     int height = 480;
+    int cameraId = 0;
     int jpeg_quality = 30;
     int rotation_angle = 0;
     int sample_rate = 44100;
@@ -21,7 +22,7 @@ struct Args {
     bool fixed_resolution = false;
     uint32_t format = V4L2_PIX_FMT_MJPEG;
     std::string v4l2_format = "mjpeg";
-    std::string device = "/dev/video0";
+    std::string camera = "libcamera:0";
     std::string uid = "";
     std::string stun_url = "stun:stun.l.google.com:19302";
     std::string turn_url = "";

--- a/src/capturer/libcamera_capturer.h
+++ b/src/capturer/libcamera_capturer.h
@@ -56,7 +56,7 @@ class LibcameraCapturer : public VideoCapturer {
     LibcameraCapturer &SetFps(int fps);
     LibcameraCapturer &SetRotation(int angle);
 
-    void Init(std::string device);
+    void Init(int deviceId);
     void AllocateBuffer();
     void RequestComplete(libcamera::Request *request);
 };

--- a/src/capturer/v4l2_capturer.cpp
+++ b/src/capturer/v4l2_capturer.cpp
@@ -13,7 +13,7 @@
 
 std::shared_ptr<V4l2Capturer> V4l2Capturer::Create(Args args) {
     auto ptr = std::make_shared<V4l2Capturer>(args);
-    ptr->Init(args.device);
+    ptr->Init(args.cameraId);
     ptr->SetFps(args.fps)
         .SetRotation(args.rotation_angle)
         .SetFormat(args.width, args.height)
@@ -28,8 +28,9 @@ V4l2Capturer::V4l2Capturer(Args args)
       has_first_keyframe_(false),
       config_(args) {}
 
-void V4l2Capturer::Init(std::string device) {
-    fd_ = V4l2Util::OpenDevice(device.c_str());
+void V4l2Capturer::Init(int deviceId) {
+    std::string devicePath = "/dev/video" + std::to_string(deviceId);
+    fd_ = V4l2Util::OpenDevice(devicePath.c_str());
 
     if (!V4l2Util::InitBuffer(fd_, &capture_, V4L2_BUF_TYPE_VIDEO_CAPTURE, V4L2_MEMORY_MMAP)) {
         exit(0);

--- a/src/capturer/v4l2_capturer.h
+++ b/src/capturer/v4l2_capturer.h
@@ -47,7 +47,7 @@ class V4l2Capturer : public VideoCapturer {
     V4l2Capturer &SetFps(int fps = 30);
     V4l2Capturer &SetRotation(int angle);
 
-    void Init(std::string device);
+    void Init(int deviceId);
     bool IsCompressedFormat() const;
     void CaptureImage();
     bool CheckMatchingDevice(std::string unique_name);

--- a/src/conductor.cpp
+++ b/src/conductor.cpp
@@ -50,7 +50,7 @@ void Conductor::InitializeTracks() {
         audio_track_ = peer_connection_factory_->CreateAudioTrack("audio_track", options.get());
     }
 
-    if (video_track_ == nullptr && !args.device.empty()) {
+    if (video_track_ == nullptr && !args.camera.empty()) {
         video_capture_source_ = ([this]() -> std::shared_ptr<VideoCapturer> {
             if (args.use_libcamera) {
                 return LibcameraCapturer::Create(args);

--- a/src/parser.h
+++ b/src/parser.h
@@ -6,6 +6,7 @@
 class Parser {
   public:
     static void ParseArgs(int argc, char *argv[], Args &args);
+    static void ParseDevice(Args &args);
 };
 
 #endif // PARSER_H_


### PR DESCRIPTION
#237 
It's only support v4l2 device can be selected originally, such as the flag `--device=/dev/video0`

Add selection support for libcamera now.
The `--device` flag is removed, it become `--camera=libcamera:0` or `--camera=v4l2:0`.
The zero in `v4l2:0` means the number in `/dev/video0`.
